### PR TITLE
Clock fix

### DIFF
--- a/chapter-07/mounting-lifecycle-clock/src/lib.js
+++ b/chapter-07/mounting-lifecycle-clock/src/lib.js
@@ -44,11 +44,13 @@ export const convertToCivilianTime = clockTime =>
     )(clockTime)
 
 export const doubleDigits = civilianTime =>
-    compose(
-        prependZero("hours"),
-        prependZero("minutes"),
-        prependZero("seconds")
-    )(civilianTime)
+    civilianTime.ampm
+      ? compose(prependZero('minutes'), prependZero('seconds'))(civilianTime)
+      : compose(
+          prependZero('hours'),
+          prependZero('minutes'),
+          prependZero('seconds'),
+        )(civilianTime)
 
 export const getClockTime = compose(
     getCurrentTime,

--- a/chapter-07/mounting-lifecycle-clock/src/lib.js
+++ b/chapter-07/mounting-lifecycle-clock/src/lib.js
@@ -54,6 +54,5 @@ export const getClockTime = compose(
     getCurrentTime,
     abstractClockTime,
     convertToCivilianTime,
-    appendAMPM,
     doubleDigits
 )


### PR DESCRIPTION
Hi there. I think the Clock code is an excellent example of functional programming - clean, with a lot being done in a small amount of code.

I just saw two things that might be changed:

- `appendAMPM` was being called twice, and because `civilianHours` had been run, it would force "am" all the time.
- You might not want to zero-pad hours on an am/pm clock but only for 24 hr. My solution for this might be able to be improved :)