### PR TITLE
Improve imperative vs declarative example

### DIFF
--- a/chapter-03/02-imperative-vs-declarative/02-imperative-declarative.html
+++ b/chapter-03/02-imperative-vs-declarative/02-imperative-declarative.html
@@ -12,7 +12,21 @@
 <script type="text/babel">
 
     const string = "This is the mid day show with Cheryl Waters"
-    const urlFriendly = string.replace(/ /g, "-").toLowerCase()
+    const makeUrlFriendly = (string) => {
+      let urlFriendlyString = ''
+
+      for (var i=0; i<string.length; i++) {
+        if (string[i] === " ") {
+          urlFriendlyString += "-"
+        } else {
+          urlFriendlyString += string[i]
+        }
+      }
+
+      return urlFriendlyString.toLowerCase()
+    }
+
+    const urlFriendly = makeUrlFriendly(string)
 
     console.log(urlFriendly)
 


### PR DESCRIPTION
This example used to compare imperative vs declarative is not really
fair to imperative programming, and might lead to some confusion,
because on the imperative example, there is an implementation, which is
not present later on the declarative example when using the built-in
`replace` function.

In my proposed change, you still keep your implementation, for which
you have full control, and abstract it yourself. In this way, the
reader sees more clearly what is actually changing from one
implementation to the next.

Additionally, considering there are two transformations to the string
in the current example, replacing the hyphens, and making the string
lowercase, it would be more declarative to create an abstraction that
does both things, thus declaring the process of "making a URL friendly"
consists, by now, of those two steps, which later on might be changed
without affecting the rest of the code.

I'm eager to see your comments on the matter, but I believe this
approach exemplifies better the difference, and concept, of imperative
vs declarative.