### PR TITLE
update "react-dom" 16.0.0 to 16.0.1 to suppress Warnings during npm i…

### DIFF
--- a/chapter-07/mounting-lifecycle-clock/package.json
+++ b/chapter-07/mounting-lifecycle-clock/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "react": "16.0.0",
-    "react-dom": "16.0.0",
+    "react-dom": "16.0.1",
     "prop-types": "15.6.0"
   }
 }


### PR DESCRIPTION
…nstall

to fix warnings during:
$ npm install
npm WARN deprecated react-dom@16.0.0: This version of react-dom/server contains a minor vulnerability. Please update react-dom to 16.0.1 or 16.4.2+. Learn more: https://fb.me/cve-2018-6341