### PR TITLE
Invoke rejects() instead of reject()

### DIFF
--- a/chapter-03/06-higher-order-functions/02-higher-order-fns.html
+++ b/chapter-03/06-higher-order-functions/02-higher-order-fns.html
@@ -18,7 +18,7 @@
       request.onload = () =>
            (request.status === 200) ?
             resolves(JSON.parse(request.response).results) :
-            reject(Error(request.statusText))
+            rejects(Error(request.statusText))
       request.onerror = (err) => rejects(err)
       request.send()
     })

--- a/chapter-03/readme.md
+++ b/chapter-03/readme.md
@@ -56,7 +56,7 @@ Many techniques in React follow the functional JavaScript paradigm. Understandin
 ### Higher Order Functions
 
 1. invokeIf ([run it](http://jsbin.com/raxuyew/1/edit?js,console))
-2. userLogs ([run it](http://jsbin.com/raxuyew/2/edit?js,console))
+2. userLogs ([run it](https://jsbin.com/bucetuwuco/edit?js,console))
 
 ### Recursion
 


### PR DESCRIPTION
Similar to the typo fixed in #25, the callback passed in as an argument is `rejects`, and not `reject`.

This can also be noticed in [the currently linked JS Bin](http://jsbin.com/raxuyew/2/edit?js,console) by [simulating an error by changing the API endpoint](https://jsbin.com/xutamojacu/edit?js,console):

```js
const api = `https://api.randomuser.me/foo/?nat=US&results=${count}`
```

the output now becomes:

```sh
"grandpa23 -> attempted to load 20 fake members"
"ReferenceError: reject is not defined
    at XMLHttpRequest.request.onload (xutamojacu.js:9:45)"
```

- [x] Fix code sample
- [x] Fix JSBin example
___

PS: Thank you @eveporcello and @MoonTahoe for the amazing book! It is a joy to read and learn from!
❤️ 💚 💙 💛 💜