### PR TITLE
Update remaining ToC entries to 2nd Ed versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ This repository contains the files for the book _Learning React_ by [Alex Banks]
 ### Table of Contents
 
 - **Chapter 1** : [Welcome To React](https://github.com/MoonHighway/learning-react/tree/second-edition/chapter-01)
-- **Chapter 2** : [Emerging JavaScript](https://github.com/MoonHighway/learning-react/tree/second-edition/chapter-02)
+- **Chapter 2** : [JavaScript for React](https://github.com/MoonHighway/learning-react/tree/second-edition/chapter-02)
 - **Chapter 3** : [Functional Programming with JavaScript](https://github.com/MoonHighway/learning-react/tree/second-edition/chapter-03)
-- **Chapter 4** : [Pure React](https://github.com/MoonHighway/learning-react/tree/second-edition/chapter-04)
+- **Chapter 4** : [How React Works](https://github.com/MoonHighway/learning-react/tree/second-edition/chapter-04)
 - **Chapter 5** : [React with JSX](https://github.com/MoonHighway/learning-react/tree/second-edition/chapter-05)
 - **Chapter 6** : [React State Management](https://github.com/MoonHighway/learning-react/tree/second-edition/chapter-06)
 - **Chapter 7** : [Enhancing Components with Hooks](https://github.com/MoonHighway/learning-react/tree/second-edition/chapter-07)
 - **Chapter 8** : [Incorporating Data](https://github.com/MoonHighway/learning-react/tree/second-edition/chapter-08)
 - **Chapter 9** : [Suspense](https://github.com/MoonHighway/learning-react/tree/second-edition/chapter-09)
-- **Chapter 10** : [Testing](https://github.com/MoonHighway/learning-react/tree/second-edition/chapter-10)
+- **Chapter 10** : [React Testing](https://github.com/MoonHighway/learning-react/tree/second-edition/chapter-10)
 - **Chapter 11** : [React Router](https://github.com/MoonHighway/learning-react/tree/second-edition/chapter-11)
 - **Chapter 12** : [React and the Server](https://github.com/MoonHighway/learning-react/tree/second-edition/chapter-12)


### PR DESCRIPTION
Some chapters in the Table of Contents still referenced the titles they had in the [1st Ed]. 
This PR brings them up to date with their [2nd Ed] versions.

  [1st Ed]: https://learning.oreilly.com/library/view/learning-react/9781491954614/
  [2nd Ed]: https://learning.oreilly.com/library/view/learning-react-2nd/9781492051718/